### PR TITLE
Disallow updates to external events

### DIFF
--- a/infra/firestore.rules
+++ b/infra/firestore.rules
@@ -5,5 +5,11 @@ service cloud.firestore {
       allow read, write: if
           request.time < timestamp.date(2022, 12, 4);
     }
+    match /appointments/{id} {
+      allow read;
+      allow create;
+      allow update: if resource.data.external == false;
+      allow delete;
+    }
   }
 }


### PR DESCRIPTION
Shouldn't break the sync projects since access via firebase-admin ignores client rules: https://stackoverflow.com/a/51931429/4571656

> Code that uses the Firebase Admin SDK with a service account to access Firestore currently can not be scoped to a particular user ID for the purpose of enforcing security rules. All access with the Admin SDK will bypass security rules and have full control of the database.

